### PR TITLE
Enable optional Rust backend via env var

### DIFF
--- a/PORTING_TO_RUST.md
+++ b/PORTING_TO_RUST.md
@@ -36,3 +36,6 @@ To keep the scope manageable, the following areas could be ported first:
 
 By re‑implementing these parts in Rust while preserving the Python API, we can begin improving performance without rewriting the entire library at once.
 
+The Rust backend is optional and can be enabled by setting the environment
+variable ``CONSTRUCT_USE_RUST`` before importing ``construct``.
+

--- a/README.rst
+++ b/README.rst
@@ -40,5 +40,15 @@ A ``Sequence`` is a collection of ordered fields, and differs from ``Array`` and
     >>> format = Sequence(PascalString(Byte, "utf8"), GreedyRange(Byte))
     >>> format.build([u"lalaland", [255,1,2]])
     b'\nlalaland\xff\x01\x02'
-    >>> format.parse(b"\x004361789432197")
-    ['', [52, 51, 54, 49, 55, 56, 57, 52, 51, 50, 49, 57, 55]]
+  >>> format.parse(b"\x004361789432197")
+  ['', [52, 51, 54, 49, 55, 56, 57, 52, 51, 50, 49, 57, 55]]
+
+Optional Rust Backend
+---------------------
+
+Construct ships with an experimental Rust implementation for selected
+functionality. By default the pure Python implementation is used. Set the
+environment variable ``CONSTRUCT_USE_RUST`` to enable the Rust version::
+
+    $ export CONSTRUCT_USE_RUST=1
+    >>> import construct

--- a/construct/__init__.py
+++ b/construct/__init__.py
@@ -19,11 +19,13 @@ Hands-on example:
     b"\x01\x02\x03"
 """
 
+import os
 from construct.core import *
-try:
-    from construct_rs import Construct as Construct
-except Exception:
-    pass
+if os.getenv("CONSTRUCT_USE_RUST"):
+    try:
+        from construct_rs import Construct as Construct
+    except Exception:
+        pass
 from construct.expr import *
 from construct.debug import *
 from construct.version import *


### PR DESCRIPTION
## Summary
- load `construct_rs` only if `CONSTRUCT_USE_RUST` environment variable is set
- document Rust backend toggle in README
- mention the environment variable in `PORTING_TO_RUST.md`

## Testing
- `python -m py_compile construct/__init__.py`
- `pytest -q` *(fails: command not found)*