### PR TITLE
Port Subconstruct to Rust

### DIFF
--- a/construct/__init__.py
+++ b/construct/__init__.py
@@ -24,6 +24,7 @@ from construct.core import *
 if os.getenv("CONSTRUCT_USE_RUST"):
     try:
         from construct_rs import Construct as Construct
+        from construct_rs import Subconstruct as Subconstruct
     except Exception:
         pass
 from construct.expr import *


### PR DESCRIPTION
## Summary
- expose `Subconstruct` implementation in `construct-rs`
- load the Rust `Subconstruct` when `CONSTRUCT_USE_RUST` is enabled

## Testing
- `cargo test` *(fails: failed to get `pyo3` as a dependency due to network restrictions)*