### PR TITLE
Add Rust BitsInteger port

### DIFF
--- a/construct/__init__.py
+++ b/construct/__init__.py
@@ -23,7 +23,7 @@ import os
 from construct.core import *
 if os.getenv("CONSTRUCT_USE_RUST"):
     try:
-        from construct_rs import Construct as Construct
+        from construct_rs import Construct as Construct, BitsInteger as BitsInteger
     except Exception:
         pass
 from construct.expr import *


### PR DESCRIPTION
## Summary
- expose a new `BitsInteger` pyclass from `construct_rs`
- use Python helpers for integer conversions
- allow selecting the Rust version of `BitsInteger` via `CONSTRUCT_USE_RUST`

## Testing
- `PYTHONPATH=. pytest -q tests/test_core.py::test_bitsinteger -s`
- `CONSTRUCT_USE_RUST=1 PYTHONPATH=. pytest -q tests/test_core.py::test_bitsinteger -s`
- `cargo check` *(fails: failed to download from `https://index.crates.io/config.json`)*